### PR TITLE
Fix unexpected behavior of comparison an issuer URLs

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -120,7 +120,7 @@ func NewProvider(ctx context.Context, issuer string) (*Provider, error) {
 		return nil, fmt.Errorf("oidc: failed to decode provider discovery object: %v", err)
 	}
 
-	if p.Issuer != issuer {
+	if strings.TrimSuffix(p.Issuer, "/") != strings.TrimSuffix(issuer, "/") {
 		return nil, fmt.Errorf("oidc: issuer did not match the issuer returned by provider, expected %q got %q", issuer, p.Issuer)
 	}
 	return &Provider{


### PR DESCRIPTION
Fixed unexpected behavior observed during validation `issuer` URL from configuration and received from a `provider`. As a different provider can return different format of URL condition couldn't determine exactly match of URLs.
An error was noticed when using **Vault** which uses this library for **OIDC Auth Backend**.
Here is an example and how to reproduce on different providers :

**Google:**

`https://accounts.google.com/.well-known/openid-configuration`
```
{
 "issuer": "https://accounts.google.com",
 "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
 "token_endpoint": "https://oauth2.googleapis.com/token",
 ...
}
```

**Auth0:**

`https://mycompany.auth0.com/.well-known/openid-configuration`
```
{
 "issuer":"https://mycompany.auth0.com/",
 "authorization_endpoint":"https://mycompany.auth0.com/authorize",
 "token_endpoint":"https://mycompany.auth0.com/oauth/token",
 ...
}
```